### PR TITLE
fix incorrect viewport calculations on homepage on chrome android

### DIFF
--- a/src/app/components/Pages/Home/home.scss
+++ b/src/app/components/Pages/Home/home.scss
@@ -1,24 +1,39 @@
 @import "scss/styles";
 
-.app.HOME {
-    .page {
-        height: 100vh;
-        padding: 0;
+@mixin chrome-mobile-fix {
+    @media screen and (-webkit-min-device-pixel-ratio:0) {
+        height: calc(100vh - 56px) !important;
+        min-height: calc(100vh - 56px) !important;
+    }  
+}
+
+.app {
+    &__page {
+        min-height: 100vh;
+        @include chrome-mobile-fix;
     }
-    .page__head {
-        height: 100vh;
-    }
-    .page__headcontent {
-        background: transparent;
-    }
-    .page__image {
-        top: 0;
-        height: 100%;
-        opacity: 0.2;
-    }
-    .topbar__search {
-        display: none;
-        visibility: hidden;
+    &.HOME {
+        .page {
+            height: 100vh;
+            padding: 0;
+            @include chrome-mobile-fix;
+        }
+        .page__head {
+            height: 100vh;
+            @include chrome-mobile-fix; 
+        }
+        .page__headcontent {
+            background: transparent;
+        }
+        .page__image {
+            top: 0;
+            height: 100%;
+            opacity: 0.2;
+        }
+        .topbar__search {
+            display: none;
+            visibility: hidden;
+        }
     }
 }
 


### PR DESCRIPTION
needs additional testing on safari since the media query also affecs safari mobile.
removes the scrolling on chrome android on the homepage