### PR TITLE
add additional query to fix grey bar on chrome desktop

### DIFF
--- a/src/app/components/Pages/Home/home.scss
+++ b/src/app/components/Pages/Home/home.scss
@@ -1,7 +1,7 @@
 @import "scss/styles";
 
 @mixin chrome-mobile-fix {
-    @media screen and (-webkit-min-device-pixel-ratio:0) {
+    @media screen and (max-width: $screen-medium) and (-webkit-min-device-pixel-ratio:0) {
         height: calc(100vh - 56px) !important;
         min-height: calc(100vh - 56px) !important;
     }  


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/3743025/41130230-03e37f70-6ab6-11e8-8947-2a68d83d8737.png)


small addition to the chrome mobile fix, only affect devices which device size is lower than the medium breakpoint 

