### PR TITLE
fix: getTime undefined issues

### DIFF
--- a/src/app/lib/api/handlePlayer.ts
+++ b/src/app/lib/api/handlePlayer.ts
@@ -72,6 +72,8 @@ export default function(player) {
         const offset = new Date().getTime() - new Date(player.serverTime).getTime();
         const available = new Date(player.updateAvailableAt).getTime() - offset;
         player.updateAvailableAt = new Date(available);
+    } else {
+        player.updateAvailableAt = new Date();
     }
 
     if (player.stats.operator) {


### PR DESCRIPTION
It appears the backend doesn't pass a updateAvailableAt  to the client (idk maybe we use the multi endpoint in some cases?)